### PR TITLE
Switch to Shiro authentication to broaden browser/websockets support

### DIFF
--- a/app.json
+++ b/app.json
@@ -9,9 +9,9 @@
   ],
   "repository": "https://github.com/heroku/zeppelin-in-space",
   "env": {
-    "ZEPPELIN_BASIC_AUTH": {
-      "description": "nginx basic auth",
-      "value": "zeppelin:{PLAIN}space"
+    "ZEPPELIN_ADMIN_PASSWORD": {
+      "description": "Password for 'admin' user access.",
+      "value": "hydrogenisflammable"
     },
     "LOG_LEVEL": {
       "description": "log4j log level for spark",

--- a/bin/zeppelin
+++ b/bin/zeppelin
@@ -5,6 +5,7 @@ set -e
 
 erb /app/conf/interpreter.json.erb > /app/zeppelin-home/conf/interpreter.json
 erb /app/conf/log4j.properties.erb > /app/zeppelin-home/conf/log4j.properties
+erb /app/conf/shiro.ini.erb > /app/zeppelin-home/conf/shiro.ini
 erb /app/conf/spark-defaults.conf.erb > /app/spark-home/conf/spark-defaults.conf
 erb /app/conf/log4j.properties.erb > /app/spark-home/conf/log4j.properties
 

--- a/conf/nginx.conf.erb
+++ b/conf/nginx.conf.erb
@@ -41,8 +41,6 @@ http {
     }
 
 		location  / {
-			auth_basic           "zeppelin-in-space";
-      auth_basic_user_file /app/space-proxy/nginx/conf/htpasswd;
 		  if ($http_cookie !~* "backend") {
         	return 307 $scheme://$host/set-backend/1.zeppelin.<%= ENV["HEROKU_DNS_APP_NAME"] %>:8080;
       }
@@ -58,8 +56,6 @@ http {
     }
 
     location /ws {  # For websocket support
-      auth_basic           "zeppelin-in-space";
-      auth_basic_user_file /app/space-proxy/nginx/conf/htpasswd;
       proxy_pass    http://$cookie_backend;
       resolver <%= ENV["RESOLVER"] %>;
       proxy_http_version 1.1;

--- a/conf/shiro.ini.erb
+++ b/conf/shiro.ini.erb
@@ -1,0 +1,36 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+[main]
+sessionManager = org.apache.shiro.web.session.mgt.DefaultWebSessionManager
+securityManager.sessionManager = $sessionManager
+# 86,400,000 milliseconds = 24 hour
+securityManager.sessionManager.globalSessionTimeout = 86400000
+shiro.loginUrl = /api/login
+
+[users]
+# List of users with their password allowed to access Zeppelin.
+# To use a different strategy (LDAP / Database / ...) check the shiro doc at http://shiro.apache.org/configuration.html#Configuration-INISections
+admin = <%= ENV["ZEPPELIN_ADMIN_PASSWORD"] %>
+
+[urls]
+# anon means the access is anonymous.
+# authcBasic means Basic Auth Security
+# authc means Form based Auth Security
+# To enfore security, comment the line below and uncomment the next one
+/api/version = anon
+/** = authc

--- a/conf/zeppelin-site.xml
+++ b/conf/zeppelin-site.xml
@@ -250,7 +250,7 @@
 
   <property>
     <name>zeppelin.anonymous.allowed</name>
-    <value>true</value>
+    <value>false</value>
     <description>Anonymous user allowed by default</description>
   </property>
 


### PR DESCRIPTION
This switches from HTTP basic auth to Login via the Zeppelin UI (user menu in the top/right corner).

✅ It does solve the Safari websockets problem.

Though, I found that Login over HTTPS goes through some mixed content warnings with the `/api/login` endpoint, but after clicking around a bit the errors don't *seem* to impair functionality.

I attempted to write the password as a salted sha256 hash, but it became complicated, so reverted to this simple plain text password match for now 😔

@sclasen do you think it's worth the switch despite the HTTPS mixed content issues?